### PR TITLE
Use port 8080 explicitly to make README examples work

### DIFF
--- a/nima/src/main/java/io/examples/helidon/nima/NimaMain.java
+++ b/nima/src/main/java/io/examples/helidon/nima/NimaMain.java
@@ -20,6 +20,7 @@ public class NimaMain {
 
     public static void main(String[] args) {
         WebServer ws = WebServer.builder()
+                .port(8080)
                 .routing(NimaMain::routing)
                 .start();
 


### PR DESCRIPTION
I noticed that port is actually randomized and the README curl examples did not work => Fixed port 8080