### PR TITLE
Add dependency helidon-config-yaml to make application.yaml work

### DIFF
--- a/nima/pom.xml
+++ b/nima/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>helidon-nima-http2-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.nima.testing.junit5</groupId>
             <artifactId>helidon-nima-testing-junit5-webserver</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Problem: server will use a available port rather than 8080 which is specified in application.yaml

Cause:  ServiceLoader cannot load class YamlConfigParser in dependency helidon-config-yaml which is missing from the pom

Fix: add the dependency helidon-config-yaml